### PR TITLE
Improve compatibility with REST Pub/Sub client

### DIFF
--- a/src/Message/JobRequest.php
+++ b/src/Message/JobRequest.php
@@ -8,9 +8,10 @@ class JobRequest implements \JsonSerializable
 {
     use HasPayloadTrait;
 
-    public const FANOUT_TYPE_FIXED = 'FIXED';
-    public const FANOUT_TYPE_RANGE = 'RANGE';
-    public const FANOUT_TYPE_FOREACH = 'FOREACH';
+    public const 
+        FANOUT_TYPE_FIXED = 'FIXED',
+        FANOUT_TYPE_RANGE = 'RANGE',
+        FANOUT_TYPE_FOREACH = 'FOREACH';
 
     protected string $action = 'default';
     protected ?int $fixedTaskCount = null;
@@ -132,7 +133,6 @@ class JobRequest implements \JsonSerializable
     {
         return [
             'data' => \json_encode($this->jsonSerialize()),
-            'attributes' => [], // for the jobRequest
         ];
     }
 

--- a/src/Message/TaskOutcome.php
+++ b/src/Message/TaskOutcome.php
@@ -30,7 +30,6 @@ class TaskOutcome implements \JsonSerializable
     {
         return [
             'data' => \json_encode($this->jsonSerialize()),
-            'attributes' => [], // for the TaskOutcome
         ];
     }
 

--- a/tests/Message/JobRequestTest.php
+++ b/tests/Message/JobRequestTest.php
@@ -123,9 +123,7 @@ class JobRequestTest extends TestCase
         $pubsub = $message->formatForPubSub();
         $this->assertIsArray($pubsub);
         $this->assertArrayHasKey('data', $pubsub);
-        $this->assertArrayHasKey('attributes', $pubsub);
         $this->assertIsString($pubsub['data']);
-        $this->assertIsArray($pubsub['attributes']);
     }
 
     public function testPayload()

--- a/tests/Message/TaskOutcomeTest.php
+++ b/tests/Message/TaskOutcomeTest.php
@@ -53,9 +53,7 @@ class TaskOutcomeTest extends TestCase
         $pubsub = $outcome->formatForPubSub();
         $this->assertIsArray($pubsub);
         $this->assertArrayHasKey('data', $pubsub);
-        $this->assertArrayHasKey('attributes', $pubsub);
         $this->assertIsString($pubsub['data']);
-        $this->assertIsArray($pubsub['attributes']);
     }
 
 }


### PR DESCRIPTION
### Changed
-  Remove empty attribute arrays from Pub/Sub payloads, which can cause older REST transports to produce invalid payloads